### PR TITLE
Fix backreference manager bug

### DIFF
--- a/BackreferenceNumberManager.js
+++ b/BackreferenceNumberManager.js
@@ -15,12 +15,17 @@ var BackreferenceNumberManager = function()
 		return n;
 	};
 
-	self.free = function(n)
-	{
-		if(used.indexOf(n) === -1) throw new Error('free BackreferenceNumber');
-		used.splice(n, 1);
-		return;
-	};
+        self.free = function(n)
+        {
+                var idx = used.indexOf(n);
+                if(idx === -1) throw new Error('free BackreferenceNumber');
+                used.splice(idx, 1);
+                return;
+        };
 
-	return self;
+        return self;
 };
+
+if (typeof module !== 'undefined') {
+        module.exports = BackreferenceNumberManager;
+}

--- a/BackreferenceNumberManager.test.js
+++ b/BackreferenceNumberManager.test.js
@@ -1,5 +1,17 @@
 const { test, expect } = require('@jest/globals');
+const BackreferenceNumberManager = require('./BackreferenceNumberManager');
 
-test('hello world!', () => {
-	expect(1 + 1).toBe(2);
+test('allocate and free numbers sequentially', () => {
+    const mgr = BackreferenceNumberManager();
+    const a = mgr.allocate();
+    const b = mgr.allocate();
+    expect(a).toBe(1);
+    expect(b).toBe(2);
+
+    mgr.free(a);
+    const c = mgr.allocate();
+    expect(c).toBe(1); // freed number should be reused
+
+    const d = mgr.allocate();
+    expect(d).toBe(3);
 });


### PR DESCRIPTION
## Summary
- fix mis-indexing when freeing a number in `BackreferenceNumberManager`
- export module for Node
- add jest test for allocate/free behavior

## Testing
- `npx jest --runInBand BackreferenceNumberManager.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684385f86f94832d937c8693ed53ae5f