### PR TITLE
Add missing test.xhtml sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Math Expression Search
+
+This repository contains experimental scripts for searching and manipulating MathML expressions. Some of the JavaScript files expect a sample XHTML document named `test.xhtml` to load and process MathML.
+
+## `test.xhtml`
+
+`queryProcessing.js` and `mregui.js` load `test.xhtml` to obtain the collection of MathML formulas that are searched or highlighted. A minimal example file is included at the repository root with two MathML expressions. You can replace this file with any valid MathML content or extend it with additional formulas.
+
+If you want to generate the file dynamically from your own MathML sources, place the resulting XHTML document at the project root as `test.xhtml` so that the scripts can access it via `loadXMLDoc()`.
+

--- a/test.xhtml
+++ b/test.xhtml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>MathML Sample</title>
+  </head>
+  <body>
+    <!-- Sample formulas for testing queryProcessing.js and mregui.js -->
+    <math xmlns="http://www.w3.org/1998/Math/MathML" id="m1">
+      <mi>a</mi><mo>+</mo><mi>b</mi><mo>=</mo><mi>c</mi>
+    </math>
+    <math xmlns="http://www.w3.org/1998/Math/MathML" id="m2">
+      <mn>2</mn><mo>&#x2062;</mo><mi>x</mi>
+    </math>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- create a simple test.xhtml with a couple of MathML examples
- document the purpose of `test.xhtml` in README

## Testing
- `npx jest` *(fails: needs installation)*

------
https://chatgpt.com/codex/tasks/task_e_68438df3c7b0832d84e7538990e6e46b